### PR TITLE
Adding initial version of AI-controlled player

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,6 +38,7 @@
     <script src="js/MovePadWidget.js"></script>
     <script src="js/WeaponInventory.js"></script>
     <script src="js/ControlPanel.js"></script>
+    <script src="js/AIController.js"></script>
 
     <!-- Terrain -->
     <script src="js/Terrain/TerrainColumn.js"></script>

--- a/docs/js/AIController.js
+++ b/docs/js/AIController.js
@@ -1,0 +1,135 @@
+class AIController {
+   static States = Object.freeze(
+      { IDLE: 'IDLE', SHOPPING: 'SHOPPING', THINKING: 'THINKING', AIMING: 'AIMING', FIRING: 'FIRING' });
+   #state = AIController.States.IDLE;
+   #location;
+   #difficulty;
+   #thinkTimer = 0;
+   #dotAnimationClock = 0;
+   #activeDots = 0;
+
+   constructor(mode, place) {
+      this.#difficulty = mode;
+      this.#location = place;
+      //this.#pickWeapon = pickWeaponCallback;
+   }
+
+   updateAI(dt, context) {
+      switch (this.#state) {
+         case AIController.States.THINKING:
+            this.#handleThinking(dt);
+            break;
+         case AIController.States.SHOPPING:
+            this.#handleShopping(context);
+            break;
+         case AIController.States.AIMING:
+            this.#handleAiming(context);
+            break;
+         case AIController.States.FIRING:
+            this.#handleFiring(context);
+            break;
+         case AIController.States.IDLE: default:
+            break;
+      }
+   }
+
+   drawThinkIndicator(position) {
+      if (this.#state !== AIController.States.THINKING) return;
+      push();
+      noStroke();
+      for (let i = 0; i < 3; i++) {
+         if (i < this.#activeDots) fill('white');
+         else fill(255, 255, 255, 100);
+         circle(position.x + (i * 20) - 20, position.y - 60, 3);
+      }
+      pop();
+   }
+
+   startThinking() {
+      if (this.#state !== AIController.States.IDLE) return;
+      if (this.#location === 'SHOP') this.#thinkTimer = random(600, 1500);
+      else this.#thinkTimer = random(1000, 5000);
+      this.#dotAnimationClock = 0;
+      this.#state = AIController.States.THINKING;
+   }
+
+   #handleThinking(dt) {
+      this.#thinkTimer -= dt;
+      this.#dotAnimationClock += dt;
+      this.#updateDots();
+      if (this.#thinkTimer <= 0) {
+         if (this.#location === 'SHOP') this.#state = AIController.States.SHOPPING;
+         else this.#state = AIController.States.AIMING;
+      }
+   }
+
+   #handleShopping(shopState) {
+      shopState.pickWeapon();
+      this.#state = AIController.States.IDLE;
+   }
+
+   #handleAiming(worldState) {
+      const bestShotParams = this.#findBestShotParams(worldState);
+      this.#applyDifficultyJitter(worldState.shooter, bestShotParams);
+      this.#state = AIController.States.FIRING;
+   }
+
+   #handleFiring(worldState) {
+      worldState.executeShot();
+      this.#state = AIController.States.IDLE;
+   }
+
+   #findBestShotParams(worldState) {
+      const { shooter, target } = worldState;
+      let bestAngle = shooter.barrelAngle;
+      let bestPower = shooter.barrelPower;
+      let minDistance = Infinity;
+      for (let testAngle = -100; testAngle > -175; testAngle -= 2) {
+         for (let testPower = 250; testPower < 650; testPower += 5) {
+            const result = this.#testMockShot(testAngle, testPower, worldState);
+            const distToEnemy = p5.Vector.dist(result.endPos, target.position);
+            if (distToEnemy < minDistance) {
+               minDistance = distToEnemy;
+               bestAngle = testAngle;
+               bestPower = testPower;
+            }
+            if (minDistance < 5) return { angle: bestAngle, power: bestPower };
+         }
+      }
+      return { angle: bestAngle, power: bestPower };
+   }
+
+   #testMockShot(angle, power, worldState) {
+      const { shooter, target, terrain, gravity, wind } = worldState;
+      const weapon = shooter.currentWeapon;
+      const { launchPos, launchVel } = TrajectoryPreview.getLaunchState(shooter, angle, power);
+      const stepForce = p5.Vector.add(gravity, wind).mult(TrajectoryPreview.simTimeStep);
+      const mockShot = { position: launchPos, velocity: launchVel, age: 0, state: {} };
+      for (let i = 0; i < TrajectoryPreview.maxSteps; i++) {
+         const result = TrajectoryPreview.simulationStep(mockShot, stepForce, terrain, target, weapon);
+         if (result.collision) return { endPos: mockShot.position };
+      }
+      return { endPos: mockShot.position };
+   }
+
+   #applyDifficultyJitter(shooter, { angle, power }) {
+      if (this.#difficulty === "easy") {
+         // Randomly offset "perfect" shot by up to 12 degrees & 60 power
+         shooter.barrelAngle = angle + random(-12, 12);
+         shooter.barrelPower = power + random(-60, 60);
+      }
+      else {
+         // Offset shot by a significantly lesser amount than easy mode
+         shooter.barrelAngle = angle + random(-1.5, 1.5);
+         shooter.barrelPower = power + random(-10, 10);
+      }
+   }
+
+   #updateDots() {
+      const cycleDuration = 2000;
+      let loopTime  = this.#dotAnimationClock % cycleDuration;
+      this.#activeDots = floor(map(loopTime, 0, cycleDuration, 0, 4));
+   }
+
+   set location(place) { this.#location = place; }
+}

--- a/docs/js/DrawUtils.js
+++ b/docs/js/DrawUtils.js
@@ -1,7 +1,7 @@
 class DrawUtils {
 
    constructor() {
-      throw new Error("DrawUtils is a static utility class and cannot be instantiated.");
+      throw new Error("DrawUtils is a static utility class and cannot be instantiated");
    }
 
    static drawLinearGradient(colorA, colorB) {
@@ -9,6 +9,28 @@ class DrawUtils {
       for (let i = 0; i < height; ++i) {
          stroke(lerpColor(colorA, colorB, i / height));
          line(0, i, width, i);
+      }
+   }
+
+   // draw a rounded rectangle with current fill and stroke styles
+   // used for glass panels and cards' glass effect in weapon shop
+   static glassRect(x, y, w, h, r) {
+      drawingContext.beginPath();
+      drawingContext.moveTo(x + r, y);
+      drawingContext.lineTo(x + w - r, y);
+      drawingContext.quadraticCurveTo(x + w, y, x + w, y + r);
+      drawingContext.lineTo(x + w, y + h - r);
+      drawingContext.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+      drawingContext.lineTo(x + r, y + h);
+      drawingContext.quadraticCurveTo(x, y + h, x, y + h - r);
+      drawingContext.lineTo(x, y + r);
+      drawingContext.quadraticCurveTo(x, y, x + r, y);
+      drawingContext.closePath();
+      if (drawingContext.fillStyle && drawingContext.fillStyle !== 'rgba(0, 0, 0, 0)') {
+         drawingContext.fill();
+      }
+      if (drawingContext.strokeStyle && drawingContext.strokeStyle !== 'rgba(0, 0, 0, 0)') {
+         drawingContext.stroke();
       }
    }
 }

--- a/docs/js/EarthquakeSystem.js
+++ b/docs/js/EarthquakeSystem.js
@@ -10,7 +10,7 @@ class EarthquakeSystem {
     }
     applyTo(projectile, dt) {
         if (!this.isActive) return;
-        projectile.vel.x += random(-0.6, 0.6) * this.intensity;
+        projectile.velocity.x += random(-0.6, 0.6) * this.intensity;
     }
 
     draw() {

--- a/docs/js/FloatingScore.js
+++ b/docs/js/FloatingScore.js
@@ -16,12 +16,12 @@ class FloatingScore {
    }
 
    _clamp(v, a, b) {
-      return Math.max(a, Math.min(b, v));
+      return max(a, min(b, v));
    }
    update() {
       this.t += 0.14;
       const tt = this._clamp(this.t, 0, 1);
-      const eased = 1 - Math.pow(1 - tt, 3);
+      const eased = 1 - pow(1 - tt, 3);
       this.x = lerp(this.x0, this.x1, eased);
       this.y = lerp(this.y0, this.y1, eased);
       if (tt >= 1) {
@@ -36,7 +36,7 @@ class FloatingScore {
       let s;
       if (typeof this.value === "number") s = (this.value > 0 ? `+${this.value}` : `${this.value}`);
       else s = String(this.value);
-      const scalePop = 1 + 0.35 * Math.exp(-6 * this.t);
+      const scalePop = 1 + 0.35 * exp(-6 * this.t);
       const baseSize = 34;
       textSize(baseSize * scalePop);
       if (typeof drawingContext !== "undefined") {

--- a/docs/js/Match.js
+++ b/docs/js/Match.js
@@ -29,10 +29,11 @@ class Match {
    #floatingScores = [];
    #trajectoryPreviewer;
    #isEasyDifficulty;
+   #computerController;
    #lastMouseButton;
    #shakeCallback;
 
-   constructor(resolution, gameMode, loadout0, loadout1, shakeCallback) {
+   constructor(resolution, gameMode, loadout0, loadout1, aiController, shakeCallback) {
       Match.#GRAVITY = createVector(0, 400);
       Match.#ZERO_VECTOR = createVector(0, 0);
       this.#width = resolution.x;
@@ -52,9 +53,11 @@ class Match {
       // Player initialisation
       this.#spawnPlayers(loadout0, loadout1);
       // Turn logic
-      this.#turnController = new TurnController(this.#wind);
+      this.#turnController = new TurnController();
       this.#isEasyDifficulty = (gameMode === "easy");
       this.#trajectoryPreviewer = new TrajectoryPreview(resolution);
+      this.#computerController = aiController;
+      this.#computerController.location = 'MATCH';
       this.#setModeBasedWeather();
       this.#shakeCallback = shakeCallback;
    }
@@ -66,6 +69,7 @@ class Match {
       this.#updateSecondaryShots(dt);
       this.#updatePoisonClouds(dt);
       this.#updateShibaImpacts();
+      this.#updateComputerController(dt);
       this.#updatePlayers();
       if (this.#currentExplosions.length > 0) this.#updateExplosions(dt);
       this.#updateFloatingScores();
@@ -77,23 +81,22 @@ class Match {
       applyShake?.();
       this.#drawEnvironment();
       this.#drawPlayers();
-      if (!this.#turnController.isGameOver) this.#drawTrajectory();
+      this.#computerController.drawThinkIndicator(this.#players[1].position);
+      if (!this.#isAIPlayerTurn()) this.#drawTrajectory();
       this.#drawShotSequence();
       pop();
       this.#drawHUD();
    }
 
    onMousePressed(button) {
-      this.#lastMouseButton = (button === LEFT || button?.left === true);
+      if (!this.#inputActive()) return;
+      this.#lastMouseButton = button?.left === true;
    }
 
    onMouseReleased() {
-      if (!this.#physicsDone() || this.#lastMouseButton !== true) return;
-      const currentPlayer = this.#players[this.#turnController.activePlayerId];
-      const inventoryResult = this.#controlPanel.handleWeaponInventoryClick();
-      if (inventoryResult.selectedIndex !== null)
-         currentPlayer.currentWeaponIndex = inventoryResult.selectedIndex;
-      if (inventoryResult.handled) return;
+      if (!this.#inputActive() || !this.#lastMouseButton) return;
+      this.#lastMouseButton = false;
+      if (this.#handleInventoryClick()) return;
       this.#handleAngleDialToggle();
       this.#handlePowerAdjustToggle();
       this.#triggerMouseCannonShot();
@@ -101,6 +104,7 @@ class Match {
    }
 
    onKeyReleased(inputKey, keyId) {
+      if (!this.#inputActive()) return;
       if (inputKey === 'Space' || keyId === 32) this.#executeCannonShot();
       if (keyId === 37) this.#executeCannonMovement('left');
       if (keyId === 39) this.#executeCannonMovement('right');
@@ -219,7 +223,7 @@ class Match {
          resolution: createVector(this.#width, this.#height)
       });
       if (impactEvent?.type === "STAR_SPLIT") this.#handleStarSplit(impactEvent);
-      else if (impactEvent) this.#handleShotImpact(impactEvent); // replaces #spawnExplosion() call
+      else if (impactEvent) this.#handleShotImpact(impactEvent);
    }
 
    #handleStarSplit(impactEvent) {
@@ -304,7 +308,7 @@ class Match {
          const craterRadius = lerp(18, 46, factor);
          target.startShibaLaunch(launchStrength, craterRadius);
          target.triggerHitFlash(8);
-         const score = Math.round(10 + factor * 160);
+         const score = round(10 + factor * 160);
          this.#updateScore(score, color(255, 160, 80));
       }
       this.#shibaImpacts.push(new ShibaImpactEffect(pos.x, pos.y, strengthFactor));
@@ -346,6 +350,18 @@ class Match {
          fx.update();
          if (fx.finished) this.#shibaImpacts.splice(i, 1);
       }
+   }
+
+   #updateComputerController(dt) {
+      if (!this.#isAIPlayerTurn() || !this.#physicsDone()) return;
+      this.#computerController.updateAI(dt, {
+         shooter: this.#players[1],
+         target: this.#players[0],
+         terrain: this.#terrain,
+         gravity: Match.#GRAVITY,
+         wind: Match.#ZERO_VECTOR,
+         executeShot: () => this.#executeCannonShot()
+      });
    }
 
    #updatePlayers() {
@@ -423,8 +439,8 @@ class Match {
       const { enemy, self } = this.#scoreCalculator.calculateExplosionScore(explosion, this.#players, this.#lastShooterId);
       if (enemy > 0) this.#updateScore(enemy, color(255, 220, 0));
       if (self > 0) this.#updateScore(-self, color(255, 80, 80));
-      this.#scoreBoard.score1 = Math.max(0, this.#scoreBoard.score1);
-      this.#scoreBoard.score2 = Math.max(0, this.#scoreBoard.score2);
+      this.#scoreBoard.score1 = max(0, this.#scoreBoard.score1);
+      this.#scoreBoard.score2 = max(0, this.#scoreBoard.score2);
    }
 
    #updateScore(extraPoints, scoreColor) {
@@ -446,6 +462,9 @@ class Match {
    #processTurnTransition() {
       if (this.#pendingTurnAdvance && this.#physicsDone()) {
          this.#turnController.advancePhase();
+         if (this.#isAIPlayerTurn()) {
+            this.#computerController.startThinking();
+         }
          this.#pendingTurnAdvance = false;
       }
    }
@@ -514,6 +533,14 @@ class Match {
       pop();
    }
 
+   #handleInventoryClick() {
+      const currentPlayer = this.#players[this.#turnController.activePlayerId];
+      const inventoryResult = this.#controlPanel.handleWeaponInventoryClick();
+      if (inventoryResult.selectedIndex !== null)
+         currentPlayer.currentWeaponIndex = inventoryResult.selectedIndex;
+      return inventoryResult.handled;
+   }
+
    #handleAngleDialToggle() {
       const dial = this.#controlPanel.angleDial;
       dial.isFollowing = (!this.#controlPanel.powerAdjust.isFollowing && dial.isHovered && !dial.isFollowing);
@@ -569,6 +596,12 @@ class Match {
          this.#poisonClouds.length === 0 &&
          this.#shibaImpacts.length === 0 &&
          this.#terrain.isSettled;
+   }
+
+   #isAIPlayerTurn() { return this.#turnController.activePlayerId === 1 }
+
+   #inputActive() {
+      return !this.#isAIPlayerTurn() && this.#physicsDone() && !this.#pendingTurnAdvance;
    }
 
    get isMatchOver() {

--- a/docs/js/PlayerCannon.js
+++ b/docs/js/PlayerCannon.js
@@ -40,7 +40,7 @@ class PlayerCannon {
       const projectile = this.#fireShot(weapon);
       if (weapon.id !== "ball") {
          this.#weaponLoadout.splice(this.#currentWeaponIndex, 1);
-         this.#currentWeaponIndex = constrain(this.#currentWeaponIndex, 0, Math.max(0, this.#weaponLoadout.length - 1));
+         this.#currentWeaponIndex = constrain(this.#currentWeaponIndex, 0, max(0, this.#weaponLoadout.length - 1));
       }
       return projectile;
    }
@@ -160,10 +160,9 @@ class PlayerCannon {
       this.#targetX = constrain(x, this.#wheelRadius, canvasWidth - this.#wheelRadius);
    }
 
-
    getDistanceTo(targetPosition) {
       const distanceToWheelCenter = p5.Vector.dist(this.#position, targetPosition);
-      const distanceToWheelSurface = Math.max(0, distanceToWheelCenter - this.#wheelRadius);
+      const distanceToWheelSurface = max(0, distanceToWheelCenter - this.#wheelRadius);
       const relativeTargetPos = p5.Vector.sub(targetPosition, this.#position);
       const restoringAngle = -this.#barrelAngle;
       // rotate target point to barrel's local coordinate system
@@ -180,6 +179,6 @@ class PlayerCannon {
          constrain(rotatedTargetPos.y, -halfBarrelSz.y, halfBarrelSz.y)
       );
       const distanceToBarrelSurface = dist(rotatedTargetPos.x, rotatedTargetPos.y, closestBarrelPoint.x, closestBarrelPoint.y);
-      return Math.min(distanceToWheelSurface, distanceToBarrelSurface);
+      return min(distanceToWheelSurface, distanceToBarrelSurface);
    }
 }

--- a/docs/js/PoisonCloud.js
+++ b/docs/js/PoisonCloud.js
@@ -56,7 +56,7 @@ class PoisonCloud {
             );
 
             const factor = constrain(1 - d / this.radius, 0, 1);
-            const poisonScore = Math.round(8 + factor * 20);
+            const poisonScore = round(8 + factor * 20);
             if (shooterId === 0) scoreBoard.score1 += poisonScore;
             else scoreBoard.score2 += poisonScore;
             floatingScores.push(

--- a/docs/js/PowerAdjustWidget.js
+++ b/docs/js/PowerAdjustWidget.js
@@ -18,8 +18,8 @@ class PowerAdjustWidget {
       this.#p1 = { x: this.#positionVector.x - 100, y: this.#positionVector.y + 100 };
       this.#p2 = { x: this.#positionVector.x + 60, y: this.#positionVector.y };
       this.#p3 = { x: this.#positionVector.x + 60, y: this.#positionVector.y + 100 };
-      const xMin = Math.min(this.#p1.x + 2, this.#p3.x - 2);
-      const xMax = Math.max(this.#p1.x + 2, this.#p3.x - 2);
+      const xMin = min(this.#p1.x + 2, this.#p3.x - 2);
+      const xMax = max(this.#p1.x + 2, this.#p3.x - 2);
       this.#sliderX = (xMin + xMax) / 2;
    }
 
@@ -28,8 +28,8 @@ class PowerAdjustWidget {
    set isFollowing(track) { this.#isFollowing = track; }
    get power() { return this.#power; }
    set power(p) {
-      const xMin = Math.min(this.#p1.x + 2, this.#p3.x - 2);
-      const xMax = Math.max(this.#p1.x + 2, this.#p3.x - 2);
+      const xMin = min(this.#p1.x + 2, this.#p3.x - 2);
+      const xMax = max(this.#p1.x + 2, this.#p3.x - 2);
       this.#sliderX = map(p, 0, 100, xMin, xMax);
       this.#power = p;
    }
@@ -99,8 +99,8 @@ class PowerAdjustWidget {
       push();
       fill(250);
 
-      const xMin = Math.min(this.#p1.x + 2, this.#p3.x - 2);
-      const xMax = Math.max(this.#p1.x + 2, this.#p3.x - 2);
+      const xMin = min(this.#p1.x + 2, this.#p3.x - 2);
+      const xMax = max(this.#p1.x + 2, this.#p3.x - 2);
 
       if (this.#isFollowing) this.#sliderX = constrain(mouseX, xMin, xMax);
 
@@ -150,7 +150,7 @@ class PowerAdjustWidget {
       textSize(16);
       textAlign(CENTER, CENTER);
 
-      const label = `Power: ${Math.round(this.#power)}`;
+      const label = `Power: ${round(this.#power)}`;
 
       text(label, (this.#p1.x + this.#p2.x) / 2, height - (this.#p3.y - this.#p2.y) * 1.75);
 

--- a/docs/js/Projectile.js
+++ b/docs/js/Projectile.js
@@ -158,7 +158,7 @@ class Projectile {
    }
 
    get position() { return this.#position; }
-   get vel() { return this.#velocity; }
+   get velocity() { return this.#velocity; }
    get isActive() { return this.#isActive; }
    set isActive(truthVal) { this.#isActive = truthVal; }
    get weapon() { return this.#weapon; }

--- a/docs/js/RainSystem.js
+++ b/docs/js/RainSystem.js
@@ -19,10 +19,10 @@ class RainSystem {
         if (!this.isActive) return;
 
         // rain drag
-        projectile.vel.y += this.intensity * 15 * dt;
+        projectile.velocity.y += this.intensity * 15 * dt;
 
         // slight air resistance
-        projectile.vel.mult(0.995);
+        projectile.velocity.mult(0.995);
     }
 
     draw(terrain) {

--- a/docs/js/ScoreBoard.js
+++ b/docs/js/ScoreBoard.js
@@ -70,11 +70,11 @@ class ScoreBoard {
    }
 
    addPointToPlayer1(points) {
-      this.score1 = Math.max(this.score1 + points, 0);
+      this.score1 = max(this.score1 + points, 0);
    }
 
    addPointToPlayer2(points) {
-      this.score2 = Math.max(this.score2 + points, 0);
+      this.score2 = max(this.score2 + points, 0);
    }
 
    getHighestScorePlayerId() {

--- a/docs/js/ScoreCalculator.js
+++ b/docs/js/ScoreCalculator.js
@@ -26,13 +26,13 @@ class ScoreCalculator {
       //If the cannon is outside the effective explosion radius, no score is given
       if (distance > explosion.maxRadius || isNaN(distance)) return 0;
       //Base score decreases as distance increases
-      const base = Math.max(0, map(distance, 0, explosion.maxRadius, 200, 0));
+      const base = max(0, map(distance, 0, explosion.maxRadius, 200, 0));
 
       let bonus = 0;
       //Bonus score depending on how close the hit is
       if (distance < explosion.maxRadius * 0.2) bonus = 80;
       else if (distance < explosion.maxRadius * 0.5) bonus = 40;
       //Final score
-      return Math.floor(base + bonus);
+      return floor(base + bonus);
    }
 }

--- a/docs/js/States/MatchState.js
+++ b/docs/js/States/MatchState.js
@@ -1,10 +1,11 @@
 class MatchState extends State {
    #match;
 
-   constructor(game, resolution, loadout0, loadout1) {
+   constructor(game, resolution, loadout0, loadout1, aiController) {
       super(game, resolution);
       const shakeLambda = (frames, mag) => this.game.effects.triggerShake(frames, mag);
-      this.#match = new Match(resolution, this.game.pendingMode, loadout0, loadout1, shakeLambda);
+      this.#match = new Match(
+         resolution, this.game.pendingMode, loadout0, loadout1, aiController, shakeLambda);
    }
 
    updateState(dt) {

--- a/docs/js/States/MenuState.js
+++ b/docs/js/States/MenuState.js
@@ -18,9 +18,6 @@ class MenuState extends State {
       if (!mode) return;
       // Go to weapon shop
       this.game.pendingMode = mode;
-      this.game.switchState(
-         new ShopState(this.game, this.resolution)
-      );
+      this.game.switchState(new ShopState(this.game, this.resolution));
    }
 }
-

--- a/docs/js/States/ShopState.js
+++ b/docs/js/States/ShopState.js
@@ -1,9 +1,15 @@
 class ShopState extends State {
    #weaponShop;
+   #aiController;
 
    constructor(game, resolution) {
       super(game, resolution);
       this.#weaponShop = new WeaponShop(resolution.x, resolution.y);
+      this.#aiController = new AIController(this.game.pendingMode, 'SHOP');
+   }
+
+   updateState(dt) {
+      this.#weaponShop.update(dt, this.#aiController);
    }
 
    drawState() {
@@ -16,7 +22,8 @@ class ShopState extends State {
          const loadout0 = this.#weaponShop.getLoadout(0);
          const loadout1 = this.#weaponShop.getLoadout(1);
          // Transition to match
-         this.game.switchState(new MatchState(this.game, this.resolution, loadout0, loadout1));
+         this.game.switchState(new MatchState(
+            this.game, this.resolution, loadout0, loadout1, this.#aiController));
       }
    }
 
@@ -28,7 +35,8 @@ class ShopState extends State {
       if (inputKey === ENTER && this.#weaponShop.isDone()) {
          const loadout0 = this.#weaponShop.getLoadout(0);
          const loadout1 = this.#weaponShop.getLoadout(1);
-         this.game.switchState(new MatchState(this.game, this.resolution, loadout0, loadout1));
+         this.game.switchState(new MatchState(
+            this.game, this.resolution, loadout0, loadout1, this.#aiController));
       }
    }
 }

--- a/docs/js/TrajectoryPreview.js
+++ b/docs/js/TrajectoryPreview.js
@@ -1,119 +1,116 @@
 class TrajectoryPreview {
-   #resolution;
-   #maxSteps = 600;
-   #simTimeStep = 0.016;
-   #hitTolerance = 20;
+   static simTimeStep = 0.016;
+   static maxSteps = 600;
+   static #hitTolerance = 20;
+   static #resolution;
 
-   constructor(resolution) { this.#resolution = resolution; }
+   constructor(resolution) { TrajectoryPreview.#resolution = resolution; }
 
-   drawPreview(player, enemy, terrain, gravityVec, windVec) {
-      const weapon = player.currentWeapon;
-      // Calculate projectile starting point
-      const { launchPos, launchVel } = this.#getLaunchState(player);
-      // Environment forces
-      const wind = createVector(windVec?.x ?? 0, windVec?.y ?? 0);
-      const targetHitRadius = enemy.wheelRadius + this.#hitTolerance;
-      // identify if this shot would hit the enemy by simulating the trajectory in advance
-      const simResult = this.#runSimulation(
-         launchPos, launchVel, gravityVec, wind, terrain, enemy, targetHitRadius, weapon
-      );
-      this.#renderPath(simResult.path, simResult.willHit);
-      if (simResult.willHit) this.#renderHitMarker(enemy.position, targetHitRadius);
+   static simulationStep(mockShot, stepForce, terrain, enemy, weapon) {
+      const hitRadius = enemy.wheelRadius + this.#hitTolerance;
+      mockShot.age += this.simTimeStep;
+      mockShot.velocity.add(stepForce);
+      weapon?.beforeProjectileStep?.(mockShot, { dt: this.simTimeStep, terrain });
+      mockShot.position.add(p5.Vector.mult(mockShot.velocity, this.simTimeStep));
+      if (this.#isOutOfBounds(mockShot.position)) return { collision: true, willHit: false };
+      if (this.#hitsEnemy(mockShot.position, enemy, hitRadius)) return { collision: true, willHit: true };
+      if (this.#hitsTerrain(mockShot.position, terrain)) return { collision: true, willHit: false };
+      return { collision: false };
    }
 
-   #getLaunchState(player) {
-      const angle = player.barrelAngle;
-      const speed = player.barrelPower;
+   static getLaunchState(player, barrelAngle, barrelPower) {
+      const angle = barrelAngle ?? player.barrelAngle;
+      const speed = barrelPower ?? player.barrelPower;
       const offset = createVector(player.wheelRadius + player.barrelSize.x / 2, 0);
       offset.rotate(angle);
       return {
-         launchPos: player.position.copy().add(offset),
+         launchPos: p5.Vector.add(player.position, offset),
          launchVel: createVector(cos(angle) * speed, sin(angle) * speed)
       }
    }
 
-   #runSimulation(pos, vel, gravity, wind, terrain, enemy, hitRadius, weapon) {
+   drawPreview(player, enemy, terrain, gravityVec, windVec) {
+      const weapon = player.currentWeapon;
+      // Calculate projectile starting point
+      const { launchPos, launchVel } = TrajectoryPreview.getLaunchState(player);
+      // Environment forces
+      const wind = createVector(windVec?.x ?? 0, windVec?.y ?? 0);
+      // identify if this shot would hit the enemy by simulating the trajectory in advance
+      const simResult = this.#runSimulation(launchPos, launchVel, gravityVec, wind, terrain, enemy, weapon);
+      this.#renderPath(simResult.path, simResult.willHit);
+      const targetHitRadius = player.wheelRadius + TrajectoryPreview.#hitTolerance;
+      if (simResult.willHit) this.#renderHitMarker(enemy.position, targetHitRadius);
+   }
+
+   #runSimulation(pos, vel, gravity, wind, terrain, enemy, weapon) {
       const path = [];
-      const stepForce = p5.Vector.add(gravity, wind).mult(this.#simTimeStep);
-      let willHit = false;
-      const mockShot = { position: pos, vel: vel, age: 0, state: {}, radius: weapon?.shotRadius ?? 4 };
-      for (let i = 0; i < this.#maxSteps; i++) {
-         const result = this.#simulationStep(mockShot, stepForce, terrain, enemy, hitRadius, weapon)
+      const stepForce = p5.Vector.add(gravity, wind).mult(TrajectoryPreview.simTimeStep);
+      const mockShot = { position: pos, velocity: vel, age: 0, state: {} };
+      for (let i = 0; i < TrajectoryPreview.maxSteps; i++) {
+         const result = TrajectoryPreview.simulationStep(mockShot, stepForce, terrain, enemy, weapon);
          this.#addToPath(mockShot.position, i, path);
          if (result.collision) return { path, willHit: result.willHit };
       }
       return { path, willHit: false };
    }
 
-   #simulationStep(mockShot, stepForce, terrain, enemy, hitRadius, weapon) {
-      mockShot.age += this.#simTimeStep;
-      mockShot.vel.add(stepForce);
-      weapon?.beforeProjectileStep?.(mockShot, { dt: this.#simTimeStep, terrain });
-      mockShot.position.add(p5.Vector.mult(mockShot.vel, this.#simTimeStep));
-      if (this.#isOutOfBounds(mockShot.position)) return { collision: true, willHit: false };
-      if (this.#hitsTerrain(mockShot.position, terrain))
-         return { collision: true, willHit: this.#hitsEnemy(mockShot.position, enemy, hitRadius) };
-      if (this.#hitsEnemy(mockShot.position, enemy, hitRadius)) return { collision: true, willHit: true };
-      return { collision: false };
+   static #isOutOfBounds(pos) {
+      return (pos.x < 0 || pos.x > this.#resolution.x || pos.y > this.#resolution.y);
    }
 
-#isOutOfBounds(pos) {
-   return (pos.x < 0 || pos.x > this.#resolution.x || pos.y > this.#resolution.y);
-}
-
-#hitsTerrain(pos, terrain) {
-   return pos.y >= terrain.getHeightAt(pos.x);
-}
-
-#hitsEnemy(pos, enemy, hitRadius) {
-   return p5.Vector.dist(pos, enemy.position) < hitRadius;
-}
-
-#addToPath(pos, i, path) {
-   if (i % 2 === 0) path.push({ pos: pos.copy(), index: i })
-}
-
-#renderPath(path, willHit) {
-   // colors for hit and miss
-   const baseColor = willHit ? [80, 255, 120] : [0, 245, 212];
-   const glowColor = willHit ? `rgba(80,255,120,` : `rgba(0,245,212,`;
-   push();
-   noStroke();
-   for (const point of path) {
-      const progress = point.index / this.#maxSteps;
-      const alpha = lerp(255, 0, progress);
-      const size = lerp(3, 0.8, progress);
-      // Glow layer
-      drawingContext.shadowBlur = lerp(18, 0, progress);
-      drawingContext.shadowColor = `${glowColor}${alpha / 255})`;
-      fill(...baseColor, alpha * 0.4);
-      circle(point.pos.x, point.pos.y, size * 1.5);
-      // Core layer
-      drawingContext.shadowBlur = lerp(8, 0, progress);
-      fill(200, 255, 250, alpha);
-      circle(point.pos.x, point.pos.y, size);
+   static #hitsTerrain(pos, terrain) {
+      return pos.y >= terrain.getHeightAt(pos.x);
    }
-   pop();
-}
 
-#renderHitMarker(targetPos, hitRadius) {
-   push();
-   drawingContext.shadowBlur = 20;
-   drawingContext.shadowColor = 'rgba(80, 255, 120, 0.9)';
-   // Pulsing circle
-   noFill();
-   stroke(80, 255, 120, 200);
-   strokeWeight(2);
-   // frameCount for pulsing effect
-   const pulse = sin(frameCount * 5) * 4;
-   circle(targetPos.x, targetPos.y, hitRadius + pulse);
-   // "HIT" text
-   noStroke();
-   drawingContext.shadowBlur = 10;
-   fill(80, 255, 120);
-   textAlign(CENTER, BOTTOM);
-   textSize(14);
-   text('HIT', targetPos.x, targetPos.y - hitRadius - 8);
-   pop();
-}
+   static #hitsEnemy(pos, enemy, hitRadius) {
+      return p5.Vector.dist(pos, enemy.position) < hitRadius;
+   }
+
+   #addToPath(pos, i, path) {
+      if (i % 2 === 0) path.push({ pos: pos.copy(), index: i })
+   }
+
+   #renderPath(path, willHit) {
+      // colors for hit and miss
+      const baseColor = willHit ? [80, 255, 120] : [0, 245, 212];
+      const glowColor = willHit ? `rgba(80,255,120,` : `rgba(0,245,212,`;
+      push();
+      noStroke();
+      for (const point of path) {
+         const progress = point.index / TrajectoryPreview.maxSteps;
+         const alpha = lerp(255, 0, progress);
+         const size = lerp(3, 0.8, progress);
+         // Glow layer
+         drawingContext.shadowBlur = lerp(18, 0, progress);
+         drawingContext.shadowColor = `${glowColor}${alpha / 255})`;
+         fill(...baseColor, alpha * 0.4);
+         circle(point.pos.x, point.pos.y, size * 1.5);
+         // Core layer
+         drawingContext.shadowBlur = lerp(8, 0, progress);
+         fill(200, 255, 250, alpha);
+         circle(point.pos.x, point.pos.y, size);
+      }
+      pop();
+   }
+
+   #renderHitMarker(targetPos, hitRadius) {
+      push();
+      drawingContext.shadowBlur = 20;
+      drawingContext.shadowColor = 'rgba(80, 255, 120, 0.9)';
+      // Pulsing circle
+      noFill();
+      stroke(80, 255, 120, 200);
+      strokeWeight(2);
+      // frameCount for pulsing effect
+      const pulse = sin(frameCount * 5) * 4;
+      circle(targetPos.x, targetPos.y, hitRadius + pulse);
+      // "HIT" text
+      noStroke();
+      drawingContext.shadowBlur = 10;
+      fill(80, 255, 120);
+      textAlign(CENTER, BOTTOM);
+      textSize(14);
+      text('HIT', targetPos.x, targetPos.y - hitRadius - 8);
+      pop();
+   }
 }

--- a/docs/js/TurnController.js
+++ b/docs/js/TurnController.js
@@ -2,9 +2,7 @@ class TurnController {
    #turnNumber = 1;
    #maxTurns = 5;
    #activePlayerId = 0;
-   #windEvent;
 
-   constructor(wind) { this.windEvent = wind; }
 
    get activePlayerId() { return this.#activePlayerId; }
    get turnNumber() { return this.#turnNumber; }

--- a/docs/js/WEAPONS/AbstractWeapon.js
+++ b/docs/js/WEAPONS/AbstractWeapon.js
@@ -27,7 +27,7 @@ class AbstractWeapon {
     // one-use style compatibility
     if (this.used) return false;
     this.used = true;
-    this.ammoLeft = Math.max(0, this.ammoLeft - 1);
+    this.ammoLeft = max(0, this.ammoLeft - 1);
     return true;
   }
 

--- a/docs/js/WEAPONS/Grapeshot.js
+++ b/docs/js/WEAPONS/Grapeshot.js
@@ -22,7 +22,7 @@ class Grapeshot extends AbstractWeapon {
     state.spread = 0;
   }
 
-  if (!state.split && (projectile.age > 0.38 || projectile.vel.y > 40)) {
+  if (!state.split && (projectile.age > 0.38 || projectile.velocity.y > 40)) {
     state.split = true;
   }
 

--- a/docs/js/WEAPONS/Lazershot.js
+++ b/docs/js/WEAPONS/Lazershot.js
@@ -17,7 +17,7 @@ class Lazershot extends AbstractWeapon {
 
  drawProjectileInstance(projectile) {
   push();
-  const dir = projectile.vel.copy();
+  const dir = projectile.velocity.copy();
   if (dir.mag() > 0) dir.normalize();
   const tail = dir.mult(34);
   stroke(120, 255, 255, 180);

--- a/docs/js/WEAPONS/Submarinshot.js
+++ b/docs/js/WEAPONS/Submarinshot.js
@@ -24,7 +24,7 @@ drawProjectileInstance(projectile) {
   noFill();
   stroke(220, 150, 255, 120);
   strokeWeight(2);
-  const dir = projectile.vel.copy();
+  const dir = projectile.velocity.copy();
   if (dir.mag() > 0) dir.normalize();
   const normal = createVector(-dir.y, dir.x).mult(6);
   line(

--- a/docs/js/WeaponInventory.js
+++ b/docs/js/WeaponInventory.js
@@ -16,7 +16,7 @@ class WeaponInventory {
 
     setWeaponLoadouts(loadouts = []) {
         this.weapons = Array.isArray(loadouts) ? loadouts : [];
-        this.#weaponsCount = Math.max(this.weapons.length, 1);
+        this.#weaponsCount = max(this.weapons.length, 1);
         if (this.weapons.length === 0) this.#currentWeapon = 0;
         else this.#currentWeapon = constrain(this.#currentWeapon, 0, this.weapons.length - 1);
     }

--- a/docs/js/WeaponShop.js
+++ b/docs/js/WeaponShop.js
@@ -36,6 +36,12 @@ class WeaponShop {
       this._panelH = gridH;
    }
 
+   update(dt, computerController) {
+      if (this._currentPlayer() && !this.isDone()) {
+         computerController.startThinking();
+      }
+      computerController.updateAI(dt, { pickWeapon: () => this.pickRandomWeapon() });
+   }
 
    isDone() {
       return this._selections.length === this.picksEach * 2;
@@ -44,22 +50,38 @@ class WeaponShop {
    getLoadout(pid) {
       return this._selections.filter(s => s.player === pid).map(s => s.weapon);
    }
-   //interaction
-   handleClick(mx, my) {
+
+   // split from handleClick(), so AI can also use it
+   selectWeaponByIndex(idx) {
       //to check if players have finished picking weapons
       // if so, no more selection allowed and store the loadout for each player
       if (this.isDone()) return;
-      const idx = this._cardAt(mx, my);
-      if (idx < 0) return;
+      if (idx < 0 || idx >= WEAPON_REGISTRY.length) return;
       const weapon = WEAPON_REGISTRY[idx];
-      if (this._selections.some(s => s.weapon.id === weapon.id)) return;
+      // Avoid taking already picked weapons
+      if (this.#isWeaponSelected(weapon.id)) return;
       const p = this._currentPlayer();
       if (p === null) return;
       this._selections.push({ weapon, player: p });
    }
 
+   //interaction
+   handleClick(mx, my) {
+      if (this._currentPlayer()) return;
+      const idx = this._cardAt(mx, my);
+      this.selectWeaponByIndex(idx);
+   }
+
    handleMouseMove(mx, my) {
+      if (this._currentPlayer()) return;
       this._hoveredIdx = this._cardAt(mx, my);
+   }
+
+   pickRandomWeapon() {
+      // '_' passed as 1st arument in map, to indicate it is only used as a filler
+      const availableIndices = WEAPON_REGISTRY.map((_, i) => i)
+         .filter(i => !this.#isWeaponSelected(WEAPON_REGISTRY[i].id));
+      if (availableIndices.length > 0) this.selectWeaponByIndex(random(availableIndices));
    }
 
    // Main draw 
@@ -142,13 +164,13 @@ class WeaponShop {
       noStroke();
       // frosted fill
       fill(r, g, b, isActive ? 28 : 12);
-      _glassRect(px, py, pw, ph, 14);
+      DrawUtils.glassRect(px, py, pw, ph, 14);
 
       // border
       noFill();
       stroke(r, g, b, isActive ? 210 : 70);
       strokeWeight(isActive ? 2 : 1.2);
-      _glassRect(px, py, pw, ph, 14);
+      DrawUtils.glassRect(px, py, pw, ph, 14);
 
       // Active glow border
       if (isActive) {
@@ -156,7 +178,7 @@ class WeaponShop {
          drawingContext.shadowColor = `rgba(${r},${g},${b},0.6)`;
          stroke(r, g, b, 140);
          strokeWeight(2);
-         _glassRect(px, py, pw, ph, 14);
+         DrawUtils.glassRect(px, py, pw, ph, 14);
          drawingContext.shadowBlur = 0;
       }
 
@@ -203,7 +225,7 @@ class WeaponShop {
             ellipseMode(CENTER);
             drawingContext.save();
             drawingContext.beginPath();
-            drawingContext.arc(slotX + 17, sy + slotH / 2, 12, 0, Math.PI * 2);
+            drawingContext.arc(slotX + 17, sy + slotH / 2, 12, 0, PI * 2);
             drawingContext.clip();
             w.drawIcon(slotX + 17, sy + slotH / 2, 11);
             drawingContext.restore();
@@ -221,10 +243,9 @@ class WeaponShop {
    // Weapon card grid to show 10 weapons, 5 per row
 
    _drawGrid() {
-      //console.log("weapons:", WEAPON_REGISTRY);
       for (let i = 0; i < Object.keys(WEAPON_REGISTRY).length; i++) {
          const col = i % this._cols;
-         const row = Math.floor(i / this._cols);
+         const row = floor(i / this._cols);
          const x = this._gridX + col * (this._cardW + this._gapX);
          const y = this._gridY + row * (this._cardH + this._gapY);
          this._drawCard(i, x, y);
@@ -263,7 +284,7 @@ class WeaponShop {
       } else {
          fill(22, 34, 62, 210);
       }
-      _glassRect(0, 0, this._cardW, this._cardH, 12);
+      DrawUtils.glassRect(0, 0, this._cardW, this._cardH, 12);
 
       // Border glow
       if (sel || isHov) {
@@ -273,7 +294,7 @@ class WeaponShop {
       noFill();
       stroke(...bdr, sel ? 230 : (isHov ? 190 : 90));
       strokeWeight(sel ? 2.2 : 1.5);
-      _glassRect(0, 0, this._cardW, this._cardH, 12);
+      DrawUtils.glassRect(0, 0, this._cardW, this._cardH, 12);
       drawingContext.shadowBlur = 0;
 
       // Inner top edge highlight (glass effect)
@@ -312,7 +333,7 @@ class WeaponShop {
       // Clip icon
       drawingContext.save();
       drawingContext.beginPath();
-      drawingContext.arc(iconCX, iconCY, iconR + 8, 0, Math.PI * 2);
+      drawingContext.arc(iconCX, iconCY, iconR + 8, 0, PI * 2);
       drawingContext.clip();
       push(); ellipseMode(CENTER);
       weapon.drawIcon(iconCX, iconCY, iconR);
@@ -400,7 +421,7 @@ class WeaponShop {
    _cardAt(mx, my) {
       for (let i = 0; i < WEAPON_REGISTRY.length; i++) {
          const col = i % this._cols;
-         const row = Math.floor(i / this._cols);
+         const row = floor(i / this._cols);
          const x = this._gridX + col * (this._cardW + this._gapX);
          const y = this._gridY + row * (this._cardH + this._gapY);
          if (mx >= x && mx <= x + this._cardW && my >= y && my <= y + this._cardH)
@@ -416,26 +437,5 @@ class WeaponShop {
       return mx >= bx && mx <= bx + 360 && my >= by && my <= by + 36;
    }
 
-}
-
-// draw a rounded rectangle with current fill and stroke styles, used for glass panels and cards
-//glass effect
-function _glassRect(x, y, w, h, r) {
-   drawingContext.beginPath();
-   drawingContext.moveTo(x + r, y);
-   drawingContext.lineTo(x + w - r, y);
-   drawingContext.quadraticCurveTo(x + w, y, x + w, y + r);
-   drawingContext.lineTo(x + w, y + h - r);
-   drawingContext.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
-   drawingContext.lineTo(x + r, y + h);
-   drawingContext.quadraticCurveTo(x, y + h, x, y + h - r);
-   drawingContext.lineTo(x, y + r);
-   drawingContext.quadraticCurveTo(x, y, x + r, y);
-   drawingContext.closePath();
-   if (drawingContext.fillStyle && drawingContext.fillStyle !== 'rgba(0, 0, 0, 0)') {
-      drawingContext.fill();
-   }
-   if (drawingContext.strokeStyle && drawingContext.strokeStyle !== 'rgba(0, 0, 0, 0)') {
-      drawingContext.stroke();
-   }
+   #isWeaponSelected(id) { return this._selections.some(s => s.weapon.id === id) }
 }

--- a/docs/js/WindSystem.js
+++ b/docs/js/WindSystem.js
@@ -17,15 +17,15 @@ class WindSystem {
       if (!this.isActive) return;
       let windEffect = this.windForce * 20;
 
-      projectile.vel.x += windEffect * dt;
+      projectile.velocity.x += windEffect * dt;
 
-      let speed = projectile.vel.mag();
+      let speed = projectile.velocity.mag();
       if (speed > 0) {
          let dragMag = this.dragCoefficient * speed * speed;
-         let dragVec = projectile.vel.copy();
+         let dragVec = projectile.velocity.copy();
          dragVec.normalize();
          dragVec.mult(-dragMag * dt);
-         projectile.vel.add(dragVec);
+         projectile.velocity.add(dragVec);
       }
    }
    draw(ctrlPanelBaseAltitude) {


### PR DESCRIPTION
This change introduces an AIController class which is used to control the second player in the game.

It is active in both weapon shop scren and the match screen.

In the shop screen, each time it is player 2's time to pick a weapon, it currently waits a random time between 0.6-1.5 seconds and then picks a random weapon.

During a match the AI plays out player 2's turn each time player 2 is active. The way it does this is by first spending a random time between 1 and 5 seconds to "think", then adjusting its' aim and finally shooting out the current weapon in its inventory with the angle and power determined during its aiming phase. It is currently unaware about having available move steps and therefore cannot consume any of them to move.

The AI's aim adjustment uses some of the same logic used to calculate the dotted curve of the trajectory preview that appears in easy mode. After finding the idial values to set its angle and power at, it gets a random jitter applied to both its angle and power. The range of the jitter is significantly larger on Easy mode than on Hard mode, so it should be much more accurate on Hard mode.

Additionally, the AI's aiming currently does not take into account the influences of the wind, rain and earthquake events on the shot's trajectory on Hard mode.

The player's clicks on the control panel's buttons have no effect during the AI-controlled player 2's turn. The buttons do, however, still highlight on mouse hover even during the AI's turn.

Another currently present bug is that during the AI's aiming phase the game freezes for about a second or so. It is more noticable on hard mode, as wind or rain particles depending on the current event can be seen freezing in place as the AI is aiming.

Most, if not all of the abovementioned issues should hopefully be addressed with fixes in future updates.