### PR TITLE
various bug fixes to AI and game state

### DIFF
--- a/docs/js/AIController.js
+++ b/docs/js/AIController.js
@@ -1,3 +1,4 @@
+// Class that controlls the computer controller player and uses an FSM to track its current state
 class AIController {
    static States = Object.freeze(
       { IDLE: 'IDLE', SHOPPING: 'SHOPPING', THINKING: 'THINKING', AIMING: 'AIMING', FIRING: 'FIRING' });
@@ -32,6 +33,7 @@ class AIController {
       }
    }
 
+   // Think indicator used to show to the player that the AI is taking its time to shoot
    drawThinkIndicator(position) {
       if (this.#state !== AIController.States.THINKING) return;
       push();
@@ -46,7 +48,7 @@ class AIController {
 
    startThinking() {
       if (this.#state !== AIController.States.IDLE) return;
-      if (this.#location === 'SHOP') this.#thinkTimer = random(600, 1500);
+      if (this.#location === 'SHOP') this.#thinkTimer = random(50, 100);
       else this.#thinkTimer = random(1000, 5000);
       this.#dotAnimationClock = 0;
       this.#state = AIController.States.THINKING;
@@ -68,6 +70,10 @@ class AIController {
    }
 
    #handleAiming(worldState) {
+      if (this.#difficulty === "easy") {
+         worldState.wind = createVector(0, 0);
+         worldState.rain = createVector(0, 0);
+      }
       const bestShotParams = this.#findBestShotParams(worldState);
       this.#applyDifficultyJitter(worldState.shooter, bestShotParams);
       this.#state = AIController.States.FIRING;
@@ -78,31 +84,53 @@ class AIController {
       this.#state = AIController.States.IDLE;
    }
 
+   // Prepare a parameters object and run it through 2 calls of runPass() to find best shot params
    #findBestShotParams(worldState) {
+      let passParams = {
+         bestAngle: worldState.shooter.barrelAngle,
+         bestPower: worldState.shooter.barrelPower,
+         minDistance: Infinity,
+         angleStep: 8,
+         powerStep: 40,
+         angleRange: [-95, -179],
+         powerRange: [250, 650]
+      }
+      // Run a coarse and a fine pass with a varying amount of steps for both angle and power
+      passParams = this.#runPass(passParams, worldState);
+      passParams.angleStep = 2;
+      passParams.powerStep = 5;
+      const { bestAngle, bestPower } = passParams;
+      passParams.angleRange = [min(-95, bestAngle + 10), max(-179, bestAngle - 10)];
+      passParams.powerRange = [max(250, bestPower - 40), min(650, bestPower + 40)];
+      passParams = this.#runPass(passParams, worldState);
+      return { angle: passParams.bestAngle, power: passParams.bestPower };
+   }
+
+   // Loop through a limited range of possible angle and power combinations,
+   // attempting to find the combination that would result in the most direct hit possible
+   #runPass(passParams, worldState) {
       const { shooter, target } = worldState;
-      let bestAngle = shooter.barrelAngle;
-      let bestPower = shooter.barrelPower;
-      let minDistance = Infinity;
-      for (let testAngle = -100; testAngle > -175; testAngle -= 2) {
-         for (let testPower = 250; testPower < 650; testPower += 5) {
+      const { angleStep, powerStep, angleRange, powerRange } = passParams;
+      for (let testAngle = angleRange[0]; testAngle > angleRange[1]; testAngle -= angleStep) {
+         for (let testPower = powerRange[0]; testPower < powerRange[1]; testPower += powerStep) {
             const result = this.#testMockShot(testAngle, testPower, worldState);
             const distToEnemy = p5.Vector.dist(result.endPos, target.position);
-            if (distToEnemy < minDistance) {
-               minDistance = distToEnemy;
-               bestAngle = testAngle;
-               bestPower = testPower;
+            if (distToEnemy < passParams.minDistance) {
+               passParams.minDistance = distToEnemy;
+               passParams.bestAngle = testAngle;
+               passParams.bestPower = testPower;
             }
-            if (minDistance < 5) return { angle: bestAngle, power: bestPower };
+            if (passParams.minDistance < 5) return passParams;
          }
       }
-      return { angle: bestAngle, power: bestPower };
+      return passParams;
    }
 
    #testMockShot(angle, power, worldState) {
-      const { shooter, target, terrain, gravity, wind } = worldState;
+      const { shooter, target, terrain, gravity, wind, rain } = worldState;
       const weapon = shooter.currentWeapon;
       const { launchPos, launchVel } = TrajectoryPreview.getLaunchState(shooter, angle, power);
-      const stepForce = p5.Vector.add(gravity, wind).mult(TrajectoryPreview.simTimeStep);
+      const stepForce = p5.Vector.add(gravity, wind).add(rain).mult(TrajectoryPreview.simTimeStep)
       const mockShot = { position: launchPos, velocity: launchVel, age: 0, state: {} };
       for (let i = 0; i < TrajectoryPreview.maxSteps; i++) {
          const result = TrajectoryPreview.simulationStep(mockShot, stepForce, terrain, target, weapon);
@@ -119,14 +147,14 @@ class AIController {
       }
       else {
          // Offset shot by a significantly lesser amount than easy mode
-         shooter.barrelAngle = angle + random(-1.5, 1.5);
+         shooter.barrelAngle = angle + random(0, 1);
          shooter.barrelPower = power + random(-10, 10);
       }
    }
 
    #updateDots() {
       const cycleDuration = 2000;
-      let loopTime  = this.#dotAnimationClock % cycleDuration;
+      let loopTime = this.#dotAnimationClock % cycleDuration;
       this.#activeDots = floor(map(loopTime, 0, cycleDuration, 0, 4));
    }
 

--- a/docs/js/Match.js
+++ b/docs/js/Match.js
@@ -78,7 +78,7 @@ class Match {
       this.#updateShibaImpacts();
       this.#updateComputerController(dt);
       this.#updateEarthWormImpacts(dt);
-      this.#updateEarthWormBump(dt)
+      this.#updateEarthWormBump(dt);
       this.#updatePlayers();
       if (this.#currentExplosions.length > 0) this.#updateExplosions(dt);
       this.#updateFloatingScores();
@@ -91,7 +91,7 @@ class Match {
       this.#drawEnvironment();
       this.#drawPlayers();
       this.#computerController.drawThinkIndicator(this.#players[1].position);
-      if (!this.#isAIPlayerTurn()) this.#drawTrajectory();
+      if (this.#inputActive()) this.#drawTrajectory();
       this.#drawShotSequence();
       pop();
       this.#drawHUD();
@@ -419,7 +419,8 @@ class Match {
          target: this.#players[0],
          terrain: this.#terrain,
          gravity: Match.#GRAVITY,
-         wind: Match.#ZERO_VECTOR,
+         wind: this.#wind ?? Match.#ZERO_VECTOR,
+         rain: this.#rain ?? Match.#ZERO_VECTOR,
          executeShot: () => this.#executeCannonShot()
       });
    }
@@ -459,6 +460,7 @@ class Match {
          }
       }
    }
+   
    #updateEarthWormBump(dt){
       for(let i = this.#earthWormBump.length - 1; i >= 0; i--){
          const bump = this.#earthWormBump[i];
@@ -607,8 +609,15 @@ class Match {
       if (!this.#isEasyDifficulty || !this.#physicsDone()) return;
       const shooter = this.#players[this.#turnController.activePlayerId];
       const target = this.#players[1 - this.#turnController.activePlayerId];
-      const noWind = Match.#ZERO_VECTOR;
-      this.#trajectoryPreviewer.drawPreview(shooter, target, this.#terrain, Match.#GRAVITY, noWind);
+      const previewParams = {
+         player: shooter,
+         enemy: target, 
+         terrain: this.#terrain, 
+         gravity: Match.#GRAVITY, 
+         wind: Match.#ZERO_VECTOR,
+         rain: Match.#ZERO_VECTOR
+      };
+      this.#trajectoryPreviewer.drawPreview(previewParams);
    }
 
    #drawShotSequence() {
@@ -632,7 +641,7 @@ class Match {
 
    #drawHUD() {
       const { turnNumber, maxTurns, activePlayerId } = this.#turnController;
-      this.#controlPanel.drawCtrlPanel(this.#players[activePlayerId], this.#physicsDone());
+      this.#controlPanel.drawCtrlPanel(this.#players[activePlayerId], this.#inputActive());
       this.#turnCounter.drawCounter(turnNumber, maxTurns, activePlayerId);
       this.#drawWeaponHUD(activePlayerId);
       for (const floatingScore of this.#floatingScores) floatingScore.draw();
@@ -731,6 +740,7 @@ class Match {
          this.#secondaryShots.length === 0 &&
          this.#poisonClouds.length === 0 &&
          this.#shibaImpacts.length === 0 &&
+         this.#earthWormImpacts.length === 0 &&
          this.#terrain.isSettled;
    }
 
@@ -797,4 +807,3 @@ class Match {
       this.#turnCounter.showSkip(playerId);
    }
 }
-

--- a/docs/js/PlayerCannon.js
+++ b/docs/js/PlayerCannon.js
@@ -116,10 +116,6 @@ class PlayerCannon {
    }
 
    #fireShot(weapon = null) {
-      //Will delete
-      console.log("fire debug");
-      console.log("andle:", this.#barrelAngle);
-      console.log("power:", this.#barrelPower);
       // offset of muzzle tip from position
       this.#savedBarrelPower = this.#barrelPower;
       const offset = createVector(this.#wheelRadius + this.#barrelSize.x / 2, 0);

--- a/docs/js/TrajectoryPreview.js
+++ b/docs/js/TrajectoryPreview.js
@@ -1,3 +1,5 @@
+// Logic used to create a dotted line showing the trajectory of a shot before it has been fired
+// Used to assist the player in Easy mode
 class TrajectoryPreview {
    static simTimeStep = 0.016;
    static maxSteps = 600;
@@ -29,23 +31,24 @@ class TrajectoryPreview {
       }
    }
 
-   drawPreview(player, enemy, terrain, gravityVec, windVec) {
-      const weapon = player.currentWeapon;
+   drawPreview(params) {
+      const { player, enemy } = params;
       // Calculate projectile starting point
       const { launchPos, launchVel } = TrajectoryPreview.getLaunchState(player);
-      // Environment forces
-      const wind = createVector(windVec?.x ?? 0, windVec?.y ?? 0);
       // identify if this shot would hit the enemy by simulating the trajectory in advance
-      const simResult = this.#runSimulation(launchPos, launchVel, gravityVec, wind, terrain, enemy, weapon);
+      const simResult = this.#runSimulation(launchPos, launchVel, params);
       this.#renderPath(simResult.path, simResult.willHit);
       const targetHitRadius = player.wheelRadius + TrajectoryPreview.#hitTolerance;
       if (simResult.willHit) this.#renderHitMarker(enemy.position, targetHitRadius);
    }
 
-   #runSimulation(pos, vel, gravity, wind, terrain, enemy, weapon) {
+   #runSimulation(launchPos, launchVel, params) {
+      const { gravity, wind, rain, terrain, enemy } = params;
+      const weapon = params.player.currentWeapon;
       const path = [];
-      const stepForce = p5.Vector.add(gravity, wind).mult(TrajectoryPreview.simTimeStep);
-      const mockShot = { position: pos, velocity: vel, age: 0, state: {} };
+      //const stepForce = p5.Vector.add(gravity, wind).add(rain).mult(TrajectoryPreview.simTimeStep);
+      const stepForce = p5.Vector.mult(gravity, TrajectoryPreview.simTimeStep);
+      const mockShot = { position: launchPos, velocity: launchVel, age: 0, state: {} };
       for (let i = 0; i < TrajectoryPreview.maxSteps; i++) {
          const result = TrajectoryPreview.simulationStep(mockShot, stepForce, terrain, enemy, weapon);
          this.#addToPath(mockShot.position, i, path);

--- a/docs/js/WEAPONS/Bubblegumshot.js
+++ b/docs/js/WEAPONS/Bubblegumshot.js
@@ -58,7 +58,7 @@ class Bubblegumshot extends AbstractWeapon {
     ellipse(0, 0, r * 2.5, r * 2.2);
     //Main sticky bubble body
     fill(255, 100, 180, 140);
-    circle(0, 0, r * 1.8, r * 1.6);
+    ellipse(0, 0, r * 1.8, r * 1.6);
     //Inner bubble
     fill(255, 60, 150, 180);
     ellipse(0, 0, r * 1.0, r * 0.9);

--- a/docs/js/WEAPONS/Earthworm.js
+++ b/docs/js/WEAPONS/Earthworm.js
@@ -3,7 +3,7 @@ class Earthworm extends AbstractWeapon {
   constructor() {
     super({
       id: 'earthworm', name: 'Earthworm',
-      description: 'Burrows underground, hiding beneath the terrain. \nMoves randomly while tracking the opponent\'s cannons, then explodes on contact.',
+      description: 'Burrows underground, hiding beneath the terrain. \nMoves randomly while tracking the opponent\'s cannon, then explodes on contact.',
       damage: 8,
       speed: 4,
       blastRadius: 8,
@@ -91,7 +91,7 @@ class Earthworm extends AbstractWeapon {
     if(!pos) return;
 
     const impactPos = pos.copy ? pos.copy() : createVector(pos.x, pos.y);
-    //Warm effect
+    //Worm effect
     match.spawnEarthWorm(impactPos, this);
   }
 }


### PR DESCRIPTION
This change contains the following:

new features:

- Updated AI aiming logic to be more accurate during wind and rain events

bug fixes:

- Significantly reduced stuttering during the AI's AIMING state
- Adjusted difficulty jitter, so AI can no longer make major angle mistakes and shoot itself on Hard mode (it can still do so on Easy mode)
- Disabled buttons' higlighting during AI's turn
- Disabled buttons while the earthworm is underground
- Changed a p5.circle() call with 4 parameters to a p5.ellipse() call in Bubblegum class to get rid of p5.js console error
- Changed drawTrajectory() call in drawMatch() to only happen, if input is inactive (previously it happened when it wasn't the AI's turn which led to edge cases where it appeared when it shouldn't have like just before moving to the results screen)

Also added a few extra comments mainly to AIController and TrajectoryPreview classes.